### PR TITLE
Setting up a barebone kickassembler devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,5 +14,10 @@ RUN apt-get update \
 RUN wget https://www.badgerpunch.com/booster/kickass.zip
 RUN wget https://www.badgerpunch.com/booster/vice.zip
 RUN unzip /kickass.zip -d tools
-RUN unzip /vice.zip -d tools
+RUN unzip /vice.zip -d tool
+
+RUN chown -R $USER_UID:$USER_GID /home/$USERNAME
+RUN mkdir -p /workspaces/boosterblaster
+RUN chown -R $USER_UID:$USER_GID /workspaces/boosterblaster
+
 USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,3 +4,6 @@ RUN apt-get update && \
     apt-get --yes --no-install-recommends install openjdk-8-jre unzip wget git 
 RUN wget https://www.badgerpunch.com/booster/kickass.zip
 RUN unzip /kickass.zip -d tools
+
+RUN wget https://www.badgerpunch.com/booster/vice.zip
+RUN unzip /vice.zip -d tools

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-# https://gist.github.com/teekaay/39bff8c66cd8e43c2ba57a6b2eef4fa8
 FROM ubuntu:latest
 
 RUN apt-get update && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM barrywalker71/kickassembler:latest

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,7 @@
-FROM barrywalker71/kickassembler:latest
+# https://gist.github.com/teekaay/39bff8c66cd8e43c2ba57a6b2eef4fa8
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install openjdk-8-jre unzip wget git 
+RUN wget https://www.badgerpunch.com/booster/kickass.zip
+RUN unzip /kickass.zip -d tools

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,18 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get --yes --no-install-recommends install openjdk-8-jre unzip wget git 
-RUN wget https://www.badgerpunch.com/booster/kickass.zip
-RUN unzip /kickass.zip -d tools
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
 
+RUN apt-get update \
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && apt-get --yes --no-install-recommends install openjdk-8-jre unzip wget git 
+RUN wget https://www.badgerpunch.com/booster/kickass.zip
 RUN wget https://www.badgerpunch.com/booster/vice.zip
+RUN unzip /kickass.zip -d tools
 RUN unzip /vice.zip -d tools
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "build": { "dockerfile": "Dockerfile" }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 {
   "name": "Kickassembler",
-  "dockerFile": "Dockerfile"
+  "dockerFile": "Dockerfile",
+  "postCreateCommand": "./postcreate.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
 {
-  "build": { "dockerfile": "Dockerfile" }
+  "name": "Kickassembler",
+  "dockerFile": "Dockerfile"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,12 +7,11 @@
             "type": "process",
             "args": [
                 "-cp",
-                "./tools/kickass/KickAss.jar",
+                "/tools/kickass/KickAss.jar",
                 "cml.kickass.KickAssembler",
                 "main.asm",
                 "-vicesymbols",
-                "-showmem",
-                "-odir ./bin"
+                "-showmem"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,8 @@
                 "cml.kickass.KickAssembler",
                 "main.asm",
                 "-vicesymbols",
-                "-showmem"
+                "-showmem",
+                "-odir bin"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "java",
+            "type": "process",
+            "args": [
+                "-cp",
+                "./tools/kickass/KickAss.jar",
+                "cml.kickass.KickAssembler",
+                "main.asm",
+                "-vicesymbols",
+                "-showmem",
+                "-odir ./bin"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/postcreate.sh
+++ b/postcreate.sh
@@ -1,1 +1,2 @@
-cp -r /tools /workspaces/boosterblaster/tools
+cp -r /tools /workspaces/boosterblaster
+chmod +x tools

--- a/postcreate.sh
+++ b/postcreate.sh
@@ -1,2 +1,2 @@
 cp -r /tools /workspaces/boosterblaster
-chmod +x tools
+chmod +x ./tools/vice/bin/x64sc.exe

--- a/postcreate.sh
+++ b/postcreate.sh
@@ -1,2 +1,3 @@
 cp -r /tools /workspaces/boosterblaster
 chmod +x ./tools/vice/bin/x64sc.exe
+chmod +x ./runProgramInEmulator.sh

--- a/postcreate.sh
+++ b/postcreate.sh
@@ -1,0 +1,1 @@
+cp -r /tools /workspaces/boosterblaster/tools

--- a/runProgramInEmulator.sh
+++ b/runProgramInEmulator.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#chmod +x ./tools/vice/bin/x64sc.exe main.prg
+./tools/vice/bin/x64sc.exe main.prg


### PR DESCRIPTION
Instead of fiddling with Java and Kickassembler, make an option to install a VS Code Devcontainer https://code.visualstudio.com/docs/remote/containers to build the .PRG file.  (It does require docker, so it is sort of replacing one dependency with a more complicated one, but docker seems to be universal these days).

Before wslg gets witespread, I guess it is easier to run WINVICE natively, but hopefully this should make getting started quicker.

When opening the folder (Open folder or ```code .```) this popup should come up.
![image](https://user-images.githubusercontent.com/1174441/179067383-3e25d841-4177-4441-adb8-7c1908490f6f.png)
